### PR TITLE
Automatically fetch public key during init

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,8 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.CI_ACCESS_TOKEN }} # TODO: This token is attached to @jaeaster personal account;
-          submodules: recursive                 #       make the contracts repo public or use a github Machine User instead
-                                                # Note: Token Expires on Sun, Dec 11 2022
+          submodules: recursive
 
-      # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.CI_ACCESS_TOKEN }} # TODO: This token is attached to @jaeaster personal account;
-          submodules: recursive                 #       make the contracts repo public or use a github Machine User instead
-                                                # Note: Token Expires on Sun, Dec 11 2022
+          submodules: recursive
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,9 @@ export class Medusa<S extends SecretKey, P extends PublicKey<S>> {
 
     switch (suite as SuiteType) {
       case SuiteType.BN254_KEYG1_HGAMAL:
-        return new Medusa(await initBn254(), signer, medusaAddress);
+        const medu = new Medusa(await initBn254(), signer, medusaAddress);
+        await medu.fetchPublicKey();
+        return medu;
       default:
         throw new Error(`unknown suite type: ${suite}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,10 +88,11 @@ export class Medusa<S extends SecretKey, P extends PublicKey<S>> {
     const suite = await medusaContract.suite();
 
     switch (suite as SuiteType) {
-      case SuiteType.BN254_KEYG1_HGAMAL:
+      case SuiteType.BN254_KEYG1_HGAMAL: {
         const medu = new Medusa(await initBn254(), signer, medusaAddress);
         await medu.fetchPublicKey();
         return medu;
+      }
       default:
         throw new Error(`unknown suite type: ${suite}`);
     }


### PR DESCRIPTION
Instead of a separate call to `fetchPublicKey` after init, we directly fetch it in the init method. This avoids one more call for the enduser.